### PR TITLE
fix typo

### DIFF
--- a/PaymentStripe.module
+++ b/PaymentStripe.module
@@ -15,7 +15,7 @@ class PaymentStripe extends PaymentModule {
 	}
 		
 	public function init() {
-		$this->currenct = $this->defaultCurrency;
+		$this->currency = $this->defaultCurrency;
 	}
 
   public function getTitle() {


### PR DESCRIPTION
Fix typo in init() function, setting the currency